### PR TITLE
make verbose more verbose

### DIFF
--- a/main.go
+++ b/main.go
@@ -857,7 +857,13 @@ func copyDep(pkg *Package) {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
+	if *flagV {
+		fmt.Println("walk", pkg.Dir)
+	}
 	filepath.Walk(pkg.Dir, func(path string, fi os.FileInfo, err error) error {
+		if *flagV {
+			fmt.Fprintln(os.Stderr, "path", path)
+		}
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil
@@ -867,6 +873,9 @@ func copyDep(pkg *Package) {
 		_, elem := filepath.Split(path)
 		dot := strings.HasPrefix(elem, ".") && elem != "." && elem != ".."
 		if dot || strings.HasPrefix(elem, "_") || elem == "testdata" {
+			if *flagV {
+				fmt.Fprintln(os.Stderr, "skipping", path)
+			}
 			return filepath.SkipDir
 		}
 
@@ -885,6 +894,9 @@ func copyDep(pkg *Package) {
 }
 
 func copyFile(dst, src string) error {
+	if *flagV {
+		fmt.Fprintln(os.Stderr, "copying", dst, src)
+	}
 	sf, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
I've been digging into #2 and added some extra logging to verbose mode. It seems like `filepath.Walk` may be the issue, but when I run the following program it works just fine. Do you see anything I may be missing?

```
$ cat x.go 
package main

import (
    "os"
    "path/filepath"
)

func main() {

    // Assumes GOPATH is a single dir.
    var dir = os.Getenv("GOPATH") + "/src/github.com/bradfitz/http2"
    filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
        println(path)
        return nil
    })
}
$ go run x.go 
/Users/bmizerany/src/github.com/bradfitz/http2
/Users/bmizerany/src/github.com/bradfitz/http2/.git
/Users/bmizerany/src/github.com/bradfitz/http2/.git/COMMIT_EDITMSG
/Users/bmizerany/src/github.com/bradfitz/http2/.git/FETCH_HEAD
/Users/bmizerany/src/github.com/bradfitz/http2/.git/HEAD
/Users/bmizerany/src/github.com/bradfitz/http2/.git/ORIG_HEAD
/Users/bmizerany/src/github.com/bradfitz/http2/.git/config
/Users/bmizerany/src/github.com/bradfitz/http2/.git/description
/Users/bmizerany/src/github.com/bradfitz/http2/.git/hooks
/Users/bmizerany/src/github.com/bradfitz/http2/.git/hooks/applypatch-msg.sample
/Users/bmizerany/src/github.com/bradfitz/http2/.git/hooks/commit-msg.sample
/Users/bmizerany/src/github.com/bradfitz/http2/.git/hooks/post-update.sample
```
